### PR TITLE
Updated to work with Jenkins 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,26 @@
 Vagrantfile and Bash script that neatly installs the latest Jenkins
 
 ### Requirements: 
- - A working Vagrant installation https://www.vagrantup.com/downloads.html
+
+A working Vagrant installation https://www.vagrantup.com/downloads.html
+
 # Instructions:
+
 Clone this repo and run vagrant up ( this may differ slightly for Windows)
+
 ```sh
 $ git clone git@github.com:Spark-Networks/vagrant-vm-for-jenkins.git
 $ cd vagrant-vm-for-jenkins
 $ vagrant up
 ```
+
 Look for the output at the end of the vagrant up process that looks like this...
+
 ```sh
 ==> default: Browse to https://localhost:8100 and use this password for initial setup: a508f6a03b8c48e6ae1157fe7633bcb3
 ==> default: Setup complete!
 ```
+
 Then browse to this site on your computer, enter in the password from the Vagrant output and begin Jenkins Setup
 
 http://localhost:8100
@@ -22,11 +29,14 @@ http://localhost:8100
 
 ### Cleanup
 Stop and Start Vagrant VM
+
 ```sh
 vagrant halt
 vagrant resume
 ```
+
 Destroy (Stops and Deletes Vagrant VM)
+
 ```sh
 vagrant destroy
 ```

--- a/README.md
+++ b/README.md
@@ -1,2 +1,34 @@
 # vagrant-vm-for-jenkins
-Vagrantfile and Bash script that neatly installs Jenkins
+Vagrantfile and Bash script that neatly installs the latest Jenkins
+
+### Requirements: 
+ - A working Vagrant installation https://www.vagrantup.com/downloads.html
+# Instructions:
+Clone this repo and run vagrant up ( this may differ slightly for Windows)
+```sh
+$ git clone git@github.com:Spark-Networks/vagrant-vm-for-jenkins.git
+$ cd vagrant-vm-for-jenkins
+$ vagrant up
+```
+Look for the output at the end of the vagrant up process that looks like this...
+```sh
+==> default: Browse to https://localhost:8100 and use this password for initial setup: a508f6a03b8c48e6ae1157fe7633bcb3
+==> default: Setup complete!
+```
+Then browse to this site on your computer, enter in the password from the Vagrant output and begin Jenkins Setup
+
+http://localhost:8100
+
+
+### Cleanup
+Stop and Start Vagrant VM
+```sh
+vagrant halt
+vagrant resume
+```
+Destroy (Stops and Deletes Vagrant VM)
+```sh
+vagrant destroy
+```
+
+

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A working Vagrant installation https://www.vagrantup.com/downloads.html
 Clone this repo and run vagrant up ( this may differ slightly for Windows)
 
 ```sh
-$ git clone git@github.com:Spark-Networks/vagrant-vm-for-jenkins.git
+$ git clone https://github.com/riojack/vagrant-vm-for-jenkins.git
 $ cd vagrant-vm-for-jenkins
 $ vagrant up
 ```

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -4,7 +4,7 @@ do_jenkins_check() {
 	printf "Waiting for Jenkins to come up."
 
 	sleep_amount_seconds=1
-	max_checks=120
+	max_checks=30
 	checks=0
 	reached_jenkins=0
 	status_code=000
@@ -37,9 +37,9 @@ do_jenkins_check() {
 
 # TIMEZONE
 # Credit: http://www.thegeekstuff.com/2010/09/change-timezone-in-linux/
-#echo "Setting timezone to America/Central"
-#rm /etc/localtime
-#ln -s /usr/share/zoneinfo/US/Central /etc/localtime
+echo "Setting timezone to America/Central"
+rm /etc/localtime
+ln -s /usr/share/zoneinfo/US/Central /etc/localtime
 
 # INSTALL JENKINS
 sudo apt-get -y remove jenkins
@@ -64,8 +64,6 @@ fi
 echo "Appending aliases to bash aliases"
 printf "\n\n. /home/vagrant/.bash_aliases" >> /home/vagrant/.bashrc
 
-service jenkins start
-
 do_jenkins_check
 
 printf "Setting up Jenkins CLI\n"
@@ -77,9 +75,9 @@ printf "\n alias jnkns=\"java -jar /home/vagrant/jenkins-cli.jar\"" >> /home/vag
 export JENKINS_URL=http://localhost:8080
 
 echo "Installing build-timeout plugin for Jenkins."
-#java -jar /home/vagrant/jenkins-cli.jar install-plugin build-timeout > /dev/null
-#java -jar /home/vagrant/jenkins-cli.jar install-plugin job-dsl > /dev/null
-#java -jar /home/vagrant/jenkins-cli.jar restart > /dev/null
+java -jar /home/vagrant/jenkins-cli.jar install-plugin build-timeout > /dev/null
+java -jar /home/vagrant/jenkins-cli.jar install-plugin job-dsl > /dev/null
+java -jar /home/vagrant/jenkins-cli.jar restart > /dev/null
 
 echo "Restarted Jenkins after installing plugins."
 do_jenkins_check


### PR DESCRIPTION
Jenkins 2.0 requires a generated admin password before continuing with the install. Modified to look for a 403 to verify that Jenkins started up and then echo out that generated password at the end of Vagrant output.

Also added some more instructions to the README
